### PR TITLE
use css to set adminbar area instead of disabling from whole

### DIFF
--- a/php/view-exhibit.php
+++ b/php/view-exhibit.php
@@ -62,6 +62,12 @@
 
 		wp_head();
 	?>
+	<style>
+	 /* fix exhibit page admin bar issue */
+		html {
+			margin-top: 0 !important;
+		}
+	</style>
 </head>
 
 <body>

--- a/php/view-volume.php
+++ b/php/view-volume.php
@@ -4,9 +4,9 @@
 <head>
 	<title><?php the_title(); ?></title>
 
-	<?php 
+	<?php
 		add_action('wp_enqueue_scripts', 'prspct_dequeue_scripts');
-		
+
 			// PURPOSE: Dequeues all scripts and styles except those used by Prospect Exhibit
 			// IMPORTANT: Must keep this list coordinated with prsp_page_template() in class-prospect.php
 		function prspct_dequeue_scripts()
@@ -61,6 +61,12 @@
 
 		wp_head();
 	?>
+	<style>
+	 /* fix exhibit page admin bar issue */
+		html {
+			margin-top: 0 !important;
+		}
+	</style>
 </head>
 
 <body>

--- a/prospect.php
+++ b/prospect.php
@@ -720,7 +720,7 @@ function prospect_init()
 	prospect_register_post_types();
 
 	// show_admin_bar(false);
-	add_filter('show_admin_bar', '__return_false');
+	// add_filter('show_admin_bar', '__return_false');
 } // prospect_init()
 
 add_action('init', 'prospect_init');


### PR DESCRIPTION
Currently the admin bar is disabled from the whole site.
I think to fix the issue in exhibition & volume page we can use css to reset the page area instead of disabling the admin bar from the whole website which may cause confusion to some WordPress users.